### PR TITLE
point to where config should be placed

### DIFF
--- a/docs/config-file.md
+++ b/docs/config-file.md
@@ -16,6 +16,10 @@ The [options](options-for-languages.md) to the configuration file are grouped by
 
 Use the [Unibeautify assistant](https://assistant.unibeautify.com/#/setup) for an interactive setup of your configuration file. Simply select the languages you want, and it will walk you though the options available. At the end simply download or copy to your clipboard your configuration.
 
+## Where to put the configuration file
+
+Whether you create the configuration file content with the Assistant or otherwise, you would next place the configuration [where Unibeautify would expect to find it](/docs/options-for-beautifiers#config-file-path).
+
 ## Example
 
 Both YAML and JSON formats are supported. You can use [json2yaml.com](https://www.json2yaml.com/) to convert from one to the other.


### PR DESCRIPTION
The current page makes no mention of where to put the configuration file/content, once created.

As this page is pointed to from the VSCode extension page, someone coming here as a new user (myself, included) would not readily know what to DO with the config file once created. I found the other page that discusses it and linked to it.  Hope it would help others.

And FWIW I created that paragraph as a new section because, I say in the proposed wording, it applies BOTH to those reading the section on the Assistant or those who do not.